### PR TITLE
Add a subject validation in PermissionRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ post = user.posts.first # assume we can get the list of posts form the user obje
 user_permissions.can?(:update, post) # returns true
 ```
 
-The condition lambda always takes two parameters, the `user` and an `object`, the object is whatever we supply to the `can?` method,
-when we check permissions.
+The condition lambda always takes two parameters, the `user` and an `object`, the object is an instance of a class we supply to the `can?` method,
+when we check permissions. Note: a permission rule with some conditions will raise an error if given a Class instead of an Instance.
 
 Let's add our admin role:
 

--- a/lib/ingress/error.rb
+++ b/lib/ingress/error.rb
@@ -1,4 +1,12 @@
 module Ingress
   class Error < StandardError
   end
+
+  class InvalidSubjectError < Error
+    DEFAULT_MESSAGE = 'This permission contains a condition lambda and can only accept an instance instead of a class.'
+
+    def initialize(msg = DEFAULT_MESSAGE)
+      super
+    end
+  end
 end

--- a/lib/ingress/error.rb
+++ b/lib/ingress/error.rb
@@ -1,0 +1,4 @@
+module Ingress
+  class Error < StandardError
+  end
+end

--- a/lib/ingress/permission_rule.rb
+++ b/lib/ingress/permission_rule.rb
@@ -4,8 +4,6 @@ module Ingress
   class PermissionRule
     attr_reader :action, :subject, :conditions
 
-    CONDITION_LAMBDA_ERROR_MESSAGE = 'This permission contains a condition lambda and can only accept an instance instead of a class.'
-
     def initialize(allows:, action:, subject:, conditions: nil)
       @allows = allows
       @action = action
@@ -35,7 +33,7 @@ module Ingress
     end
 
     def raise_error!
-      raise Ingress::Error.new(CONDITION_LAMBDA_ERROR_MESSAGE)
+      raise InvalidSubjectError.new
     end
 
     def action_matches?(given_action)

--- a/lib/ingress/permission_rule.rb
+++ b/lib/ingress/permission_rule.rb
@@ -1,6 +1,10 @@
+require "ingress/error"
+
 module Ingress
   class PermissionRule
     attr_reader :action, :subject, :conditions
+
+    CONDITION_LAMBDA_ERROR_MESSAGE = 'This permission contains a condition lambda and can only accept an instance instead of a class.'
 
     def initialize(allows:, action:, subject:, conditions: nil)
       @allows = allows
@@ -14,14 +18,25 @@ module Ingress
     end
 
     def match?(given_action, given_subject, user, options = {})
+      validate_given_subject!(given_subject, conditions)
+
       return false unless action_matches?(given_action)
       return false unless subject_matches?(given_subject)
-      return true if ignore_conditions?(given_subject)
 
       conditions_match?(user, given_subject, options)
     end
 
     private
+
+    def validate_given_subject!(subject, conditions)
+      has_some_conditions =  !(conditions.nil? || conditions.size == 0)
+
+      raise_error! if (subject_class?(subject) && has_some_conditions)
+    end
+
+    def raise_error!
+      raise Ingress::Error.new(CONDITION_LAMBDA_ERROR_MESSAGE)
+    end
 
     def action_matches?(given_action)
       given_action == action ||
@@ -36,12 +51,9 @@ module Ingress
         "*" == subject
     end
 
-    def ignore_conditions?(given_subject)
-      subject_class?(given_subject) && subject_class?(@subject)
-    end
-
-    def subject_class?(subject)
-      [Class, Module].include? subject.class
+    def subject_class?(given_subject)
+      [Class, Module].include?(given_subject.class) &&
+      [Class, Module].include?(@subject.class)
     end
 
     def conditions_match?(user, given_subject, options)

--- a/lib/ingress/version.rb
+++ b/lib/ingress/version.rb
@@ -1,3 +1,3 @@
 module Ingress
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/spec/ingress_spec.rb
+++ b/spec/ingress_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "securerandom"
+require "ingress/error"
 
 RSpec.describe Ingress do
   class TestUser
@@ -129,8 +130,10 @@ RSpec.describe Ingress do
       end
 
       context "when class is given instead of instance" do
-        it "should fail but shouldn't error" do
-          expect(permissions.can?(:update, TestObject)).to be_falsy
+        it "should raise an error" do
+          expect { permissions.can?(:update, TestObject) }.to raise_error(
+            Ingress::Error, 'This permission contains a condition lambda and can only accept an instance instead of a class.'
+          )
         end
       end
     end
@@ -436,8 +439,10 @@ RSpec.describe Ingress do
         expect(permissions.can?(:foo, TestObject.new(id: 4))).to be_falsy
       end
 
-      it "should be able to do action if Class is provided" do
-        expect(permissions.can?(:with_block, TestObject)).to be_truthy
+      it "raises an error if Class is provided" do
+        expect { permissions.can?(:with_block, TestObject) }.to raise_error(
+          Ingress::Error, 'This permission contains a condition lambda and can only accept an instance instead of a class.'
+        )
       end
     end
 

--- a/spec/ingress_spec.rb
+++ b/spec/ingress_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Ingress do
       context "when class is given instead of instance" do
         it "should raise an error" do
           expect { permissions.can?(:update, TestObject) }.to raise_error(
-            Ingress::Error, 'This permission contains a condition lambda and can only accept an instance instead of a class.'
+            Ingress::InvalidSubjectError, 'This permission contains a condition lambda and can only accept an instance instead of a class.'
           )
         end
       end
@@ -441,7 +441,7 @@ RSpec.describe Ingress do
 
       it "raises an error if Class is provided" do
         expect { permissions.can?(:with_block, TestObject) }.to raise_error(
-          Ingress::Error, 'This permission contains a condition lambda and can only accept an instance instead of a class.'
+          Ingress::InvalidSubjectError, 'This permission contains a condition lambda and can only accept an instance instead of a class.'
         )
       end
     end


### PR DESCRIPTION
Currently the interface for a Permission Rule accept conditions but do
not apply the conditions when the given subject is a class.

This issue leads to undesired behaviour where the consumer of this gem
may define a permission_rule with conditions and passing a class
expecting the conditions to work but it will return true.

This commit adds a validation that raises an error when a
permission_rule with some conditions are given a class instead of an
instance.